### PR TITLE
Speculatively remove/skip tests per P2602

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -693,7 +693,8 @@ concept indirectly_copyable_storable = indirectly_copyable<_In, _Out>
 
 namespace ranges {
     namespace _Iter_swap {
-        void iter_swap();
+        template <class _Ty1, class _Ty2>
+        void iter_swap(_Ty1, _Ty2) = delete;
 
         // clang-format off
         template <class _Ty1, class _Ty2>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -693,8 +693,7 @@ concept indirectly_copyable_storable = indirectly_copyable<_In, _Out>
 
 namespace ranges {
     namespace _Iter_swap {
-        template <class _Ty1, class _Ty2>
-        void iter_swap(_Ty1, _Ty2) = delete;
+        void iter_swap();
 
         // clang-format off
         template <class _Ty1, class _Ty2>
@@ -1640,10 +1639,7 @@ namespace ranges {
     concept _Should_range_access = is_lvalue_reference_v<_Rng> || enable_borrowed_range<remove_cvref_t<_Rng>>;
 
     namespace _Begin {
-        template <class _Ty>
-        void begin(_Ty&) = delete;
-        template <class _Ty>
-        void begin(const _Ty&) = delete;
+        void begin();
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
@@ -1764,10 +1760,7 @@ namespace ranges {
     }
 
     namespace _End {
-        template <class _Ty>
-        void end(_Ty&) = delete;
-        template <class _Ty>
-        void end(const _Ty&) = delete;
+        void end();
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
@@ -1945,10 +1938,7 @@ namespace ranges {
     }
 
     namespace _Rbegin {
-        template <class _Ty>
-        void rbegin(_Ty&) = delete;
-        template <class _Ty>
-        void rbegin(const _Ty&) = delete;
+        void rbegin();
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
@@ -2013,10 +2003,7 @@ namespace ranges {
     }
 
     namespace _Rend {
-        template <class _Ty>
-        void rend(_Ty&) = delete;
-        template <class _Ty>
-        void rend(const _Ty&) = delete;
+        void rend();
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
@@ -2115,10 +2102,7 @@ namespace ranges {
     inline constexpr bool disable_sized_range = false;
 
     namespace _Size {
-        template <class _Ty>
-        void size(_Ty&) = delete;
-        template <class _Ty>
-        void size(const _Ty&) = delete;
+        void size();
 
         template <class _Ty, class _UnCV>
         concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty __t) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -89,6 +89,9 @@ std/utilities/format/format.functions/vformat.pass.cpp FAIL
 # libc++ doesn't implement P2321R2's changes to vector<bool>::reference
 std/containers/sequences/vector.bool/iterator_concept_conformance.compile.pass.cpp FAIL
 
+# libc++ doesn't implement P2602R0 "Poison Pills are Too Toxic"
+std/ranges/range.access/begin.pass.cpp FAIL
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -89,6 +89,9 @@ utilities\format\format.functions\vformat.pass.cpp
 # libc++ doesn't implement P2321R2's changes to vector<bool>::reference
 containers\sequences\vector.bool\iterator_concept_conformance.compile.pass.cpp
 
+# libc++ doesn't implement P2602R0 "Poison Pills are Too Toxic"
+ranges\range.access\begin.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1810,65 +1810,6 @@ STATIC_ASSERT(ranges::viewable_range<std::span<int> const&>);
 STATIC_ASSERT(ranges::viewable_range<std::span<int>>);
 STATIC_ASSERT(ranges::viewable_range<std::span<int> const>);
 
-namespace poison_pill_test {
-    template <class T>
-    auto begin(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto begin(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto end(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto end(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rbegin(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rbegin(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rend(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rend(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto size(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto size(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-
-    struct some_type {};
-
-    // The above underconstrained templates should be blocked by the poison pills for the ranges CPOs tested below;
-    // that is not the case in N4849, which P2091 will fix.
-
-    STATIC_ASSERT(!CanBegin<some_type&>);
-    STATIC_ASSERT(!CanBegin<some_type const&>);
-    STATIC_ASSERT(!CanEnd<some_type&>);
-    STATIC_ASSERT(!CanEnd<some_type const&>);
-    STATIC_ASSERT(!CanRBegin<some_type&>);
-    STATIC_ASSERT(!CanRBegin<some_type const&>);
-    STATIC_ASSERT(!CanREnd<some_type&>);
-    STATIC_ASSERT(!CanREnd<some_type const&>);
-    STATIC_ASSERT(!CanSize<some_type&>);
-    STATIC_ASSERT(!CanSize<some_type const&>);
-} // namespace poison_pill_test
-
 namespace unwrapped_begin_end {
     // Validate the iterator-unwrapping range access CPOs ranges::_Ubegin and ranges::_Uend
     using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::Sized, test::IsWrapped;


### PR DESCRIPTION
The check should pass after these changes. And then we are able to _speculatively implement_ P2602R0 in MSVC STL.