### PR TITLE
Speculatively remove/skip tests per P2602

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -271,6 +271,7 @@
 // P2415R2 What Is A view?
 // P2418R2 Add Support For std::generator-like Types To std::format
 // P2432R1 Fix istream_view
+// P2602R0 Poison Pills are Too Toxic
 // P????R? directory_entry::clear_cache()
 
 // _HAS_CXX20 indirectly controls:

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -89,6 +89,9 @@ std/utilities/format/format.functions/vformat.pass.cpp FAIL
 # libc++ doesn't implement P2321R2's changes to vector<bool>::reference
 std/containers/sequences/vector.bool/iterator_concept_conformance.compile.pass.cpp FAIL
 
+# libc++ doesn't implement P2602R0 "Poison Pills are Too Toxic"
+std/ranges/range.access/begin.pass.cpp FAIL
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -89,6 +89,9 @@ utilities\format\format.functions\vformat.pass.cpp
 # libc++ doesn't implement P2321R2's changes to vector<bool>::reference
 containers\sequences\vector.bool\iterator_concept_conformance.compile.pass.cpp
 
+# libc++ doesn't implement P2602R0 "Poison Pills are Too Toxic"
+ranges\range.access\begin.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1810,65 +1810,6 @@ STATIC_ASSERT(ranges::viewable_range<std::span<int> const&>);
 STATIC_ASSERT(ranges::viewable_range<std::span<int>>);
 STATIC_ASSERT(ranges::viewable_range<std::span<int> const>);
 
-namespace poison_pill_test {
-    template <class T>
-    auto begin(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto begin(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto end(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto end(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rbegin(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rbegin(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rend(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto rend(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto size(T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-    template <class T>
-    auto size(const T&) {
-        STATIC_ASSERT(always_false<T>);
-    }
-
-    struct some_type {};
-
-    // The above underconstrained templates should be blocked by the poison pills for the ranges CPOs tested below;
-    // that is not the case in N4849, which P2091 will fix.
-
-    STATIC_ASSERT(!CanBegin<some_type&>);
-    STATIC_ASSERT(!CanBegin<some_type const&>);
-    STATIC_ASSERT(!CanEnd<some_type&>);
-    STATIC_ASSERT(!CanEnd<some_type const&>);
-    STATIC_ASSERT(!CanRBegin<some_type&>);
-    STATIC_ASSERT(!CanRBegin<some_type const&>);
-    STATIC_ASSERT(!CanREnd<some_type&>);
-    STATIC_ASSERT(!CanREnd<some_type const&>);
-    STATIC_ASSERT(!CanSize<some_type&>);
-    STATIC_ASSERT(!CanSize<some_type const&>);
-} // namespace poison_pill_test
-
 namespace unwrapped_begin_end {
     // Validate the iterator-unwrapping range access CPOs ranges::_Ubegin and ranges::_Uend
     using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::Sized, test::IsWrapped;


### PR DESCRIPTION
The check should pass after these changes. And then we are able to _speculatively implement_ P2602R0 in MSVC STL.

Towards microsoft/STL#2799.